### PR TITLE
Ignore missing properties option

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,9 @@ interface ServiceConfig {
     // If you want that some and count requests are bundled into multi requests.
     multiRequest?: boolean;
 
+    // If you want that the ignoreMissingProperties parameter to be set for each post request.
+    ignoreMissingProperties?: boolean;
+
     // Optional request/response interceptors.
     interceptors?: {
 

--- a/src/generator/01-base/static/globalConfig.ts.txt
+++ b/src/generator/01-base/static/globalConfig.ts.txt
@@ -23,6 +23,9 @@ export interface ServiceConfig {
     // If you want that some and count requests are bundled into multi requests.
     multiRequest?: boolean;
 
+    // If you want that the ignoreMissingProperties parameter to be set to true for every post request.
+    ignoreMissingProperties?: boolean;
+
     // Optional request/response interceptors.
     interceptors?: {
 

--- a/src/generator/01-base/static/root.ts.txt
+++ b/src/generator/01-base/static/root.ts.txt
@@ -119,11 +119,11 @@ const _update = (
     cfg: ServiceConfigWithoutMultiRequest | undefined,
     endpoint: string,
     data: any,
-    {ignoreMissingProperties = true, dryRun = false}: UpdateQuery = {}
+    {ignoreMissingProperties, dryRun = false}: UpdateQuery = {}
 ) => wrapResponse(() => raw({...cfg, multiRequest: false}, endpoint, {
     method: 'PUT',
     body: data,
-    query: {ignoreMissingProperties, dryRun}
+    query: {ignoreMissingProperties: ignoreMissingProperties ?? cfg?.ignoreMissingProperties ?? globalConfig?.ignoreMissingProperties, dryRun}
 }));
 
 const _unique = (


### PR DESCRIPTION
Added ignore missing properties config option.

The MultiRequest branch should be merged before.