### PR TITLE
Ignore "multipartUpload" instead of "multiPartUpload"

### DIFF
--- a/src/generator/04-services/utils/groupEndpointsByEntity.ts
+++ b/src/generator/04-services/utils/groupEndpointsByEntity.ts
@@ -11,7 +11,7 @@ export type GroupedEndpoints = Map<string, ParsedEndpoint[]>;
 
 const isMultiPartUploadPath = (path: string) => {
     const [, entity, ...rest] = path.split('/');
-    return entity && rest.length === 2 && rest[1] === 'multiPartUpload';
+    return entity && rest.length === 2 && rest[1] === 'multipartUpload';
 };
 
 export const groupEndpointsByEntity = (paths: OpenAPIV3.PathsObject): GroupedEndpoints => {


### PR DESCRIPTION
The method name was changed in the api from multipartUpload to multiPartUpload, so the skip method had to be adapted.