### PR TITLE
feat: make requests abortable

### DIFF
--- a/src/generator/01-base/static/globalConfig.ts.txt
+++ b/src/generator/01-base/static/globalConfig.ts.txt
@@ -40,6 +40,10 @@ export interface ServiceConfig {
     };
 }
 
+export interface RequestOptions {
+    signal?: AbortSignal;
+}
+
 type ServiceConfigWithoutMultiRequest = Omit<ServiceConfig, 'multiRequest'>;
 
 let globalConfig: ServiceConfig | undefined;

--- a/src/generator/01-base/static/root.ts.txt
+++ b/src/generator/01-base/static/root.ts.txt
@@ -1,7 +1,8 @@
 export const raw = async (
     cfg: ServiceConfig | undefined,
     endpoint: string,
-    payload: RequestPayload = {}
+    payload: RequestPayload = {},
+    requestOptions?: RequestOptions
 ): Promise<any> => {
     const globalConfig = getGlobalConfig();
     if (!cfg && !globalConfig) {
@@ -13,7 +14,7 @@ export const raw = async (
         interceptors: {...globalConfig?.interceptors, ...cfg?.interceptors}
     };
 
-     const isBinaryData = payload.body instanceof resolveBinaryObject();
+    const isBinaryData = payload.body instanceof resolveBinaryObject();
     const params = new URLSearchParams(Object.entries(payload.query ?? {}).filter(v => v[1] !== undefined)
       .map(([key, value]) => [key, typeof value === "string" ? value : JSON.stringify(value)]));
 
@@ -48,7 +49,7 @@ export const raw = async (
         });
         let res = await interceptRequest(request, payload) ?? request;
         if (!(res instanceof Response)) {
-            res = await fetch(res);
+            res = requestOptions?.signal ?  await fetch(res, { signal: requestOptions.signal } ) : await fetch(res);
         }
         res = await interceptResponse(res) ?? res;
         data = (!payload.forceBlob || !res.ok) && res.headers?.get('content-type')?.includes('application/json') ?
@@ -66,7 +67,8 @@ export const raw = async (
 const _count = (
     cfg: ServiceConfig | undefined,
     endpoint: string,
-    query?: CountQuery<any> & {params?: Record<any, any>}
+    query?: CountQuery<any> & {params?: Record<any, any>},
+    requestOptions?: RequestOptions
 ) => wrapResponse(() => raw(cfg, endpoint, {
     unwrap: true,
     query: {
@@ -75,12 +77,13 @@ const _count = (
         ...assembleFilterParam(query?.where),
         ...query?.params
     }
-}));
+}, requestOptions));
 
 const _some = (
     cfg: ServiceConfig | undefined,
     endpoint: string,
-    query?: SomeQuery<any, any, any, any, any> & {params?: Record<any, any>}
+    query?: SomeQuery<any, any, any, any, any> & {params?: Record<any, any>},
+    requestOptions?: RequestOptions
 ) => wrapResponse(() => raw(cfg, endpoint, {
         query: {
             serializeNulls: query?.serializeNulls,
@@ -94,7 +97,7 @@ const _some = (
             ...query?.params,
             ...query?.pagination
         }
-    }).then(data => ({
+    }, requestOptions).then(data => ({
         entities: data.result,
         references: data.referencedEntities ?? {},
         properties: data.additionalProperties ?? {}
@@ -104,47 +107,52 @@ const _some = (
 const _remove = (
     cfg: ServiceConfigWithoutMultiRequest | undefined,
     endpoint: string,
-    {dryRun = false}: RemoveQuery = {}
+    {dryRun = false}: RemoveQuery = {},
+    requestOptions?: RequestOptions
 ) => wrapResponse(() => raw({...cfg, multiRequest: false}, endpoint, {
     method: 'DELETE',
     query: {dryRun}
-}).then(() => undefined));
+}, requestOptions).then(() => undefined));
 
 const _create = (
     cfg: ServiceConfigWithoutMultiRequest | undefined,
     endpoint: string,
-    data: any
+    data: any,
+    requestOptions?: RequestOptions
 ) => wrapResponse(() => raw({...cfg, multiRequest: false}, endpoint, {
     method: 'POST',
     body: data
-}));
+}, requestOptions));
 
 const _update = (
     cfg: ServiceConfigWithoutMultiRequest | undefined,
     endpoint: string,
     data: any,
-    {ignoreMissingProperties, dryRun = false}: UpdateQuery = {}
+    {ignoreMissingProperties, dryRun = false}: UpdateQuery = {},
+    requestOptions?: RequestOptions
 ) => wrapResponse(() => raw({...cfg, multiRequest: false}, endpoint, {
     method: 'PUT',
     body: data,
     query: {ignoreMissingProperties: ignoreMissingProperties ?? cfg?.ignoreMissingProperties ?? globalConfig?.ignoreMissingProperties, dryRun}
-}));
+}, requestOptions));
 
 const _unique = (
     cfg: ServiceConfigWithoutMultiRequest | undefined,
     endpoint: string,
-    query?: UniqueQuery
-) => wrapResponse(() => raw({...cfg, multiRequest: false}, endpoint, {query}));
+    query?: UniqueQuery,
+    requestOptions?: RequestOptions
+) => wrapResponse(() => raw({...cfg, multiRequest: false}, endpoint, {query}, requestOptions));
 
 const _generic = (
     cfg: ServiceConfigWithoutMultiRequest | undefined,
     method: RequestPayloadMethod,
     endpoint: string,
     payload?: GenericQuery<any, any>,
-    forceBlob?: boolean
+    forceBlob?: boolean,
+    requestOptions?: RequestOptions
 ) => wrapResponse(() => raw({...cfg, multiRequest: false}, endpoint, {
     method,
     forceBlob,
     body: payload?.body,
     query: payload?.params
-}));
+}, requestOptions));

--- a/src/generator/04-services/endpoints/count.ts
+++ b/src/generator/04-services/endpoints/count.ts
@@ -36,14 +36,14 @@ export const generateCountEndpoint: ServiceFunctionGenerator = ({
   const functionSource = generateArrowFunction({
     name: functionName,
     signature: interfaceName,
-    returns: `_${functionName}(cfg, ${generateString(endpoint.path)}, query)`,
-    params: ["query"],
+    returns: `_${functionName}(cfg, ${generateString(endpoint.path)}, query, requestOptions)`,
+    params: ["query", "requestOptions?: RequestOptions"],
   });
 
   const interfaceSource = generateArrowFunctionType({
     type: interfaceName,
     params: [
-      `query${parameters.isFullyOptional() ? "?" : ""}: CountQuery<${entityFilter}> & ${entityParameters}`,
+      `query${parameters.isFullyOptional() ? "?" : ""}: CountQuery<${entityFilter}> & ${entityParameters}`, "requestOptions?: RequestOptions",
     ],
     returns: `${resolveResponseType(target)}<number>`,
   });

--- a/src/generator/04-services/endpoints/create.ts
+++ b/src/generator/04-services/endpoints/create.ts
@@ -23,13 +23,13 @@ export const generateCreateEndpoint: ServiceFunctionGenerator = ({
   const functionSource = generateArrowFunction({
     name: functionName,
     signature: interfaceName,
-    returns: `_${functionName}(cfg, ${generateString(endpoint.path)}, data)`,
-    params: ["data"],
+    returns: `_${functionName}(cfg, ${generateString(endpoint.path)}, data, requestOptions)`,
+    params: ["data", "requestOptions?: RequestOptions"],
   });
 
   const interfaceSource = generateArrowFunctionType({
     type: interfaceName,
-    params: [`data: DeepPartial<${generateRequestBodyType(path).toString()}>`],
+    params: [`data: DeepPartial<${generateRequestBodyType(path).toString()}>`, "requestOptions?: RequestOptions"],
     returns: `${resolveResponseType(target)}<${generateResponseBodyType(path).toString()}>`,
   });
 

--- a/src/generator/04-services/endpoints/generic.ts
+++ b/src/generator/04-services/endpoints/generic.ts
@@ -55,15 +55,15 @@ export const generateGenericEndpoint =
     const functionSource = generateArrowFunction({
       name: functionName,
       signature: interfaceName,
-      params: hasId ? ["id", "query"] : ["query"],
-      returns: `_generic(cfg, ${generateString(method.toUpperCase())}, \`${insertPathPlaceholder(endpoint.path, { id: "${id}" })}\`, query, ${forceBlobResponse})`,
+      params: hasId ? ["id", "query", "requestOptions?: RequestOptions"] : ["query", "requestOptions?: RequestOptions"],
+      returns: `_generic(cfg, ${generateString(method.toUpperCase())}, \`${insertPathPlaceholder(endpoint.path, { id: "${id}" })}\`, query, ${forceBlobResponse}, requestOptions)`,
     });
 
     const interfaceSource = generateArrowFunctionType({
       type: interfaceName,
       params: [
         ...(hasId ? ["id: string"] : []),
-        `query${params.isFullyOptional() ? "?" : ""}: ${entityQuery}`,
+        `query${params.isFullyOptional() ? "?" : ""}: ${entityQuery}`, "requestOptions?: RequestOptions"
       ],
       returns: `${resolveResponseType(target)}<${wrapBody(responseBody, target).toString()}>`,
     });

--- a/src/generator/04-services/endpoints/remove.ts
+++ b/src/generator/04-services/endpoints/remove.ts
@@ -20,13 +20,13 @@ export const generateRemoveEndpoint: ServiceFunctionGenerator = ({
   const functionSource = generateArrowFunction({
     name: functionName,
     signature: interfaceName,
-    returns: `_${functionName}(cfg, \`${insertPathPlaceholder(endpoint.path, { id: "${id}" })}\`, options)`,
-    params: ["id", "options?: RemoveQuery"],
+    returns: `_${functionName}(cfg, \`${insertPathPlaceholder(endpoint.path, { id: "${id}" })}\`, options, requestOptions)`,
+    params: ["id", "options?: RemoveQuery", "requestOptions?: RequestOptions"],
   });
 
   const interfaceSource = generateArrowFunctionType({
     type: interfaceName,
-    params: ["id: string", "options?: RemoveQuery"],
+    params: ["id: string", "options?: RemoveQuery", "requestOptions?: RequestOptions"],
     returns: `${resolveResponseType(target)}<void>`,
   });
 

--- a/src/generator/04-services/endpoints/some.ts
+++ b/src/generator/04-services/endpoints/some.ts
@@ -92,7 +92,7 @@ export const generateSomeEndpoint: ServiceFunctionGenerator = ({
       `I extends (QuerySelect<${entityMappings}> | undefined) = undefined`,
     ],
     params: [
-      `query${parameters.isFullyOptional() ? "?" : ""}: SomeQuery<${entity}, ${entityFilter}, I, S, ${additionalPropertyNamesType}> & ${entityParameters}`,
+      `query${parameters.isFullyOptional() ? "?" : ""}: SomeQuery<${entity}, ${entityFilter}, I, S, ${additionalPropertyNamesType}> & ${entityParameters}`, "requestOptions?: RequestOptions",
     ],
     returns: `${resolveResponseType(target)}<SomeQueryReturn<${entity}, ${entityReferences}, ${entityMappings}, I, S, ${properties}>>`,
   });
@@ -100,8 +100,8 @@ export const generateSomeEndpoint: ServiceFunctionGenerator = ({
   const functionSource = generateArrowFunction({
     name: functionName,
     signature: interfaceName,
-    returns: `_${functionName}(cfg, ${generateString(endpoint.path)}, query)`,
-    params: ["query"],
+    returns: `_${functionName}(cfg, ${generateString(endpoint.path)}, query, requestOptions)`,
+    params: ["query", "requestOptions?: RequestOptions"],
   });
 
   return {

--- a/src/generator/04-services/endpoints/unique.ts
+++ b/src/generator/04-services/endpoints/unique.ts
@@ -22,13 +22,13 @@ export const generateUniqueEndpoint: ServiceFunctionGenerator = ({
   const functionSource = generateArrowFunction({
     name: functionName,
     signature: interfaceName,
-    params: ["id", "query"],
-    returns: `_${functionName}(cfg, \`${insertPathPlaceholder(endpoint.path, { id: "${id}" })}\`, query)`,
+    params: ["id", "query", "requestOptions?: RequestOptions"],
+    returns: `_${functionName}(cfg, \`${insertPathPlaceholder(endpoint.path, { id: "${id}" })}\`, query, requestOptions)`,
   });
 
   const interfaceSource = generateArrowFunctionType({
     type: interfaceName,
-    params: ["id: string", "query?: Q"],
+    params: ["id: string", "query?: Q", "requestOptions?: RequestOptions"],
     generics: ["Q extends UniqueQuery"],
     returns: `${resolveResponseType(target)}<${generateResponseBodyType(path).toString()}>`,
   });

--- a/src/generator/04-services/endpoints/update.ts
+++ b/src/generator/04-services/endpoints/update.ts
@@ -26,6 +26,7 @@ export const generateUpdateEndpoint: ServiceFunctionGenerator = ({
       "id: string",
       `data: DeepPartial<${generateRequestBodyType(path).toString()}>`,
       "options?: UpdateQuery",
+      "requestOptions?: RequestOptions"
     ],
     returns: `${resolveResponseType(target)}<${generateResponseBodyType(path).toString()}>`,
   });
@@ -33,8 +34,8 @@ export const generateUpdateEndpoint: ServiceFunctionGenerator = ({
   const functionSource = generateArrowFunction({
     name: functionName,
     signature: interfaceName,
-    returns: `_${functionName}(cfg, \`${insertPathPlaceholder(endpoint.path, { id: "${id}" })}\`, data, options)`,
-    params: ["id", "data", "options"],
+    returns: `_${functionName}(cfg, \`${insertPathPlaceholder(endpoint.path, { id: "${id}" })}\`, data, options, requestOptions)`,
+    params: ["id", "data", "options", "requestOptions?: RequestOptions"],
   });
 
   return {


### PR DESCRIPTION
Requests can be aborted now by passing a signal to the request.