### PR TITLE
Remove filter prop

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,10 +4,10 @@ To work on the SDK generator you need to do the following:
 
 1. Clone this repo using git, you need to have nodejs installed.
 2. Run `npm install` in the cloned directory.
-3. Run `npm run cli:watch`.
-4. Run `npm run sdk:build` to build the SDK from env. You might want to check out [.tmp](.tmp) for the locally built SDK.
+3. Run `npm run build:watch`.
+4. Run `npm run cli:<browser|node>` to build the SDK from env. You might want to check out [sdk](../sdk) for the locally built SDK.
 
-During development, the SDK will first be generated into the [.tmp](./.tmp) directory and then bundled and stored in the [sdk](./sdk) folder.
+During development, the SDK will be generated, bundled and stored in the [sdk](../sdk) folder.
 In production the root folder will be used.
 
 As of v1.9.0 this repository uses [conventional commit messages](https://conventionalcommits.org).

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ interface Args {
   deprecated?: boolean;
   fromEnv?: boolean;
   target?: Target;
+  generateFilter?: boolean;
   _: (string | number)[];
 }
 
@@ -86,6 +87,10 @@ export const cli = async (): Promise<CLIResult> => {
       describe: "Include deprecated functions and services",
       type: "boolean",
     })
+    .option("generate-filter", {
+      describe: "Generate the old filter property for some and count queries",
+      type: "boolean",
+    })
     .epilog(`Copyright ${new Date().getFullYear()} weclapp GmbH`) as {
     argv: Args;
   };
@@ -108,6 +113,7 @@ export const cli = async (): Promise<CLIResult> => {
     deprecated,
     generateUnique: argv.generateUnique ?? false,
     target: argv.target ?? Target.BROWSER_PROMISES,
+    generateFilter: argv.generateFilter ?? false,
   };
 
   if (!src || typeof src === "number") {

--- a/src/generator/01-base/index.ts
+++ b/src/generator/01-base/index.ts
@@ -3,6 +3,8 @@ import { generateImport } from "@ts/generateImport";
 import { generateStatements } from "@ts/generateStatements";
 import globalConfig from "./static/globalConfig.ts.txt";
 import multiRequest from "./static/multiRequest.ts.txt";
+import queriesWithFilter from "./static/queriesWithFilter.ts.txt";
+import queriesWithoutFilter from "./static/queriesWithoutFilter.ts.txt";
 import root from "./static/root.ts.txt";
 import types from "./static/types.ts.txt";
 
@@ -24,7 +26,11 @@ const resolveMappings = (target: Target) =>
 const resolveBinaryClass = (target: Target) =>
   `const resolveBinaryObject = () => ${resolveBinaryType(target)};`;
 
-export const generateBase = (target: Target, apiVersion: string): string => {
+export const generateBase = (
+  target: Target,
+  apiVersion: string,
+  generateFilter?: boolean,
+): string => {
   return generateStatements(
     resolveImports(target),
     resolveMappings(target),
@@ -32,6 +38,7 @@ export const generateBase = (target: Target, apiVersion: string): string => {
     `const apiVersion = ${apiVersion}`,
     globalConfig,
     multiRequest,
+    generateFilter ? queriesWithFilter : queriesWithoutFilter,
     types,
     root,
   );

--- a/src/generator/01-base/static/queriesWithFilter.ts.txt
+++ b/src/generator/01-base/static/queriesWithFilter.ts.txt
@@ -1,0 +1,89 @@
+// Endpoint configurations
+export type CountQuery<F> = {
+    filter?: QueryFilter<F>;
+    where?: QueryFilterNew<F> & CustomAttributeFilter;
+    or?: (QueryFilter<F> & CustomAttributeFilter)[];
+};
+
+
+export type SomeQuery<
+    E, // Entity
+    F, // Entity filter
+    I extends (QuerySelect<any> | undefined), // Select for referenced entities
+    S extends (QuerySelect<any> | undefined), // Select for entity properties
+    P extends string[] // Select for additional properties
+> = {
+    serializeNulls?: boolean;
+    include?: I;
+    properties?: P
+    filter?: QueryFilter<F> & CustomAttributeFilter;
+    where?: QueryFilterNew<F> & CustomAttributeFilter;
+    select?: S;
+    or?: (QueryFilter<F> & CustomAttributeFilter)[];
+    sort?: Sort<E>[];
+    pagination?: Pagination;
+};
+
+const _count = (
+    cfg: ServiceConfig | undefined,
+    endpoint: string,
+    query?: CountQuery<any> & {params?: Record<any, any>}
+) => wrapResponse(() => raw(cfg, endpoint, {
+    unwrap: true,
+    query: {
+        ...flattenFilter(query?.filter),
+        ...flattenOrFilter(query?.or),
+        ...assembleFilterParam(query?.where),
+        ...query?.params
+    }
+}));
+
+const _some = (
+    cfg: ServiceConfig | undefined,
+    endpoint: string,
+    query?: SomeQuery<any, any, any, any, any> & {params?: Record<any, any>}
+) => wrapResponse(() => raw(cfg, endpoint, {
+        query: {
+            serializeNulls: query?.serializeNulls,
+            additionalProperties: query?.properties?.join(','),
+            properties: query?.select ? flattenSelect(query.select).join(',') : undefined,
+            includeReferencedEntities: query?.include ? Object.keys(query.include).join(',') : undefined,
+            ...flattenOrFilter(query?.or),
+            ...flattenFilter(query?.filter),
+            ...assembleFilterParam(query?.where),
+            ...flattenSort(query?.sort),
+            ...query?.params,
+            ...query?.pagination
+        }
+    }).then(data => ({
+        entities: data.result,
+        references: data.referencedEntities ?? {},
+        properties: data.additionalProperties ?? {}
+    }))
+);
+
+const flattenFilter = (obj: QueryFilter<any> = {}): Record<string, string> => {
+    const filter: [string, any][] = [], customAttributes: [string, any][] = [];
+
+    Object.entries(obj).forEach(value => {
+        (value[0].match(/^\d+$/) ? customAttributes : filter).push(value);
+    });
+
+    return Object.fromEntries([
+        ...flatten(Object.fromEntries(filter)),
+        ...flattenCustomAttributes(Object.fromEntries(customAttributes) as CustomAttributeFilter)
+    ]);
+};
+
+const flattenOrFilter = (obj: QueryFilter<any>[] = []): Record<string, string> => {
+    const entries: [string, any][] = [];
+
+    for (let i = 0; i < obj.length; i++) {
+        entries.push(
+            ...flatten(obj[i])
+                .map(v => [`or${i || ''}-${v[0]}`, v[1]]) as [string, string][]
+        );
+    }
+
+    return Object.fromEntries(entries);
+};

--- a/src/generator/01-base/static/queriesWithoutFilter.ts.txt
+++ b/src/generator/01-base/static/queriesWithoutFilter.ts.txt
@@ -1,0 +1,55 @@
+// Endpoint configurations
+export type CountQuery<F> = {
+    where?: QueryFilterNew<F> & CustomAttributeFilter;
+};
+
+
+export type SomeQuery<
+    E, // Entity
+    F, // Entity filter
+    I extends (QuerySelect<any> | undefined), // Select for referenced entities
+    S extends (QuerySelect<any> | undefined), // Select for entity properties
+    P extends string[] // Select for additional properties
+> = {
+    serializeNulls?: boolean;
+    include?: I;
+    properties?: P
+    where?: QueryFilterNew<F> & CustomAttributeFilter;
+    select?: S;
+    sort?: Sort<E>[];
+    pagination?: Pagination;
+};
+
+const _count = (
+    cfg: ServiceConfig | undefined,
+    endpoint: string,
+    query?: CountQuery<any> & {params?: Record<any, any>}
+) => wrapResponse(() => raw(cfg, endpoint, {
+    unwrap: true,
+    query: {
+        ...assembleFilterParam(query?.where),
+        ...query?.params
+    }
+}));
+
+const _some = (
+    cfg: ServiceConfig | undefined,
+    endpoint: string,
+    query?: SomeQuery<any, any, any, any, any> & {params?: Record<any, any>}
+) => wrapResponse(() => raw(cfg, endpoint, {
+        query: {
+            serializeNulls: query?.serializeNulls,
+            additionalProperties: query?.properties?.join(','),
+            properties: query?.select ? flattenSelect(query.select).join(',') : undefined,
+            includeReferencedEntities: query?.include ? Object.keys(query.include).join(',') : undefined,
+            ...assembleFilterParam(query?.where),
+            ...flattenSort(query?.sort),
+            ...query?.params,
+            ...query?.pagination
+        }
+    }).then(data => ({
+        entities: data.result,
+        references: data.referencedEntities ?? {},
+        properties: data.additionalProperties ?? {}
+    }))
+);

--- a/src/generator/01-base/static/root.ts.txt
+++ b/src/generator/01-base/static/root.ts.txt
@@ -63,43 +63,9 @@ export const raw = async (
     return payload.unwrap ? data.result : data;
 };
 
-const _count = (
-    cfg: ServiceConfig | undefined,
-    endpoint: string,
-    query?: CountQuery<any> & {params?: Record<any, any>}
-) => wrapResponse(() => raw(cfg, endpoint, {
-    unwrap: true,
-    query: {
-        ...flattenFilter(query?.filter),
-        ...flattenOrFilter(query?.or),
-        ...assembleFilterParam(query?.where),
-        ...query?.params
-    }
-}));
 
-const _some = (
-    cfg: ServiceConfig | undefined,
-    endpoint: string,
-    query?: SomeQuery<any, any, any, any, any> & {params?: Record<any, any>}
-) => wrapResponse(() => raw(cfg, endpoint, {
-        query: {
-            serializeNulls: query?.serializeNulls,
-            additionalProperties: query?.properties?.join(','),
-            properties: query?.select ? flattenSelect(query.select).join(',') : undefined,
-            includeReferencedEntities: query?.include ? Object.keys(query.include).join(',') : undefined,
-            ...flattenOrFilter(query?.or),
-            ...flattenFilter(query?.filter),
-            ...assembleFilterParam(query?.where),
-            ...flattenSort(query?.sort),
-            ...query?.params,
-            ...query?.pagination
-        }
-    }).then(data => ({
-        entities: data.result,
-        references: data.referencedEntities ?? {},
-        properties: data.additionalProperties ?? {}
-    }))
-);
+
+
 
 const _remove = (
     cfg: ServiceConfigWithoutMultiRequest | undefined,

--- a/src/generator/01-base/static/types.ts.txt
+++ b/src/generator/01-base/static/types.ts.txt
@@ -90,34 +90,9 @@ export type MapKeys<T, S extends Record<keyof T, string>> = {
     [K in keyof T as S[K]]: T[K];
 };
 
-// Endpoint configurations
-export type CountQuery<F> = {
-    filter?: QueryFilter<F>;
-    where?: QueryFilterNew<F> & CustomAttributeFilter;
-    or?: (QueryFilter<F> & CustomAttributeFilter)[];
-};
-
 export type Pagination = {
     page: number;
     pageSize: number;
-};
-
-export type SomeQuery<
-    E, // Entity
-    F, // Entity filter
-    I extends (QuerySelect<any> | undefined), // Select for referenced entities
-    S extends (QuerySelect<any> | undefined), // Select for entity properties
-    P extends string[] // Select for additional properties
-> = {
-    serializeNulls?: boolean;
-    include?: I;
-    properties?: P
-    filter?: QueryFilter<F> & CustomAttributeFilter;
-    where?: QueryFilterNew<F> & CustomAttributeFilter;
-    select?: S;
-    or?: (QueryFilter<F> & CustomAttributeFilter)[];
-    sort?: Sort<E>[];
-    pagination?: Pagination;
 };
 
 export type UniqueQuery = {
@@ -345,32 +320,6 @@ const flattenWhere = (obj: QueryFilterNew<any> = {}, nestedPaths: string[]): str
 const assembleFilterParam = (obj: QueryFilterNew<any> = {}): Record<string, string> => {
     const flattedFilter = flattenWhere(obj, []);
     return flattedFilter.length ? { filter: flattedFilter.join(' and ') }: {}
-};
-
-const flattenFilter = (obj: QueryFilter<any> = {}): Record<string, string> => {
-    const filter: [string, any][] = [], customAttributes: [string, any][] = [];
-
-    Object.entries(obj).forEach(value => {
-        (value[0].match(/^\d+$/) ? customAttributes : filter).push(value);
-    });
-
-    return Object.fromEntries([
-        ...flatten(Object.fromEntries(filter)),
-        ...flattenCustomAttributes(Object.fromEntries(customAttributes) as CustomAttributeFilter)
-    ]);
-};
-
-const flattenOrFilter = (obj: QueryFilter<any>[] = []): Record<string, string> => {
-    const entries: [string, any][] = [];
-
-    for (let i = 0; i < obj.length; i++) {
-        entries.push(
-            ...flatten(obj[i])
-                .map(v => [`or${i || ''}-${v[0]}`, v[1]]) as [string, string][]
-        );
-    }
-
-    return Object.fromEntries(entries);
 };
 
 const flattenSelect = (obj: Select<any, any> = {}): string[] => {

--- a/src/generator/generate.ts
+++ b/src/generator/generate.ts
@@ -16,6 +16,8 @@ export interface GeneratorOptions {
   target: Target;
   /* Generate deprecated functions */
   deprecated: boolean;
+  /* Generate the old filter property for some and count queries */
+  generateFilter: boolean;
 }
 
 export const generate = (


### PR DESCRIPTION
The filter property of SomeQuery and CountQuery will be removed later. Therefore we should prepare the removal.

I added a new flag --generate-filter to remove filter property by default. Only if flag is set the filter property is generated.