### PR TITLE
Lower case enums

### DIFF
--- a/src/ts/generateEnum.ts
+++ b/src/ts/generateEnum.ts
@@ -2,7 +2,11 @@ import { generateString } from "@ts/generateString";
 import { indent } from "@utils/indent";
 import { snakeCase } from "change-case";
 
-const transformKey = (s: string) => snakeCase(s).toUpperCase();
+const transformKey = (s: string) => {
+  const asSnakeCase = snakeCase(s);
+
+  return asSnakeCase === s ? asSnakeCase : asSnakeCase.toUpperCase();
+};
 
 export const generateEnum = (name: string, values: string[]): string => {
   const props = indent(


### PR DESCRIPTION
Some enums are generated by the SDK with lower case values (due to some naming conventions). This causes compiler errors. Therefore, a generation mechanism for lower case keys was added.