### PR TITLE
Prevent empty IN-queries

### DIFF
--- a/src/generator/01-base/static/queriesWithFilter.ts.txt
+++ b/src/generator/01-base/static/queriesWithFilter.ts.txt
@@ -16,8 +16,10 @@ export type ArrayOperator = 'IN' | 'NOT_IN';
 
 export type Operator = EqualityOperator | ComparisonOperator | ArrayOperator;
 
+export type NonEmptyArray<T> = [T, ...T[]];
+
 export type MapOperators<T> = { [K in EqualityOperator]?: T | null } & { [K in ComparisonOperator]?: T } & {
-  [K in ArrayOperator]?: T[];
+  [K in ArrayOperator]?: NonEmptyArray<T>;
 };
 
 export type QueryFilter<T> = {

--- a/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
+++ b/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
@@ -15,12 +15,14 @@ export type Operator = ComparisonOperator | ArrayOperator | NullOperator;
 
 export type ModifierFunction = 'lower';
 
+export type NonEmptyArray<T> = [T, ...T[]];
+
 export type MapOperators<T> =
-  | ({ [K in ComparisonOperator]?: T } & { [K in ArrayOperator]?: T[] } & {
+  | ({ [K in ComparisonOperator]?: T } & { [K in ArrayOperator]?: NonEmptyArray<T> } & {
       [K in NullOperator]?: never } & {
       [K in ModifierFunction]?: boolean
     })
-  | ({ [K in ComparisonOperator]?: T } & { [K in ArrayOperator]?: T[] } & {
+  | ({ [K in ComparisonOperator]?: T } & { [K in ArrayOperator]?: NonEmptyArray<T> } & {
       [K in NullOperator]?: boolean } & {
       [K in ModifierFunction]?: never
     });


### PR DESCRIPTION
Empty IN-queries will always result in API-error. Therefor I added a new type for non-empty arrays which is used in the query filters.