### PR TITLE
Allow ternary operator in filter expressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -688,9 +688,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1586,9 +1586,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1978,9 +1978,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2917,9 +2917,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3088,9 +3088,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
-      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "version": "5.5.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
+      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
       "dev": true,
       "funding": [
         {
@@ -3101,8 +3101,8 @@
       "license": "MIT",
       "dependencies": {
         "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -3369,13 +3369,14 @@
       "dev": true
     },
     "node_modules/handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "wordwrap": "^1.0.0"
       },
@@ -4319,9 +4320,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
       "dev": true,
       "funding": [
         {
@@ -4364,9 +4365,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4763,9 +4764,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"
@@ -4984,9 +4985,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
       "dev": true,
       "funding": [
         {
@@ -5510,9 +5511,9 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -5887,9 +5888,9 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-          "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+          "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
           "dev": true,
           "requires": {
             "balanced-match": "^4.0.2"
@@ -6402,9 +6403,9 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-          "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+          "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
           "dev": true,
           "requires": {
             "balanced-match": "^4.0.2"
@@ -6659,9 +6660,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -7326,9 +7327,9 @@
           "dev": true
         },
         "brace-expansion": {
-          "version": "5.0.4",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-          "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+          "version": "5.0.5",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+          "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
           "dev": true,
           "requires": {
             "balanced-match": "^4.0.2"
@@ -7457,14 +7458,14 @@
       }
     },
     "fast-xml-parser": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
-      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
+      "version": "5.5.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
+      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
       "dev": true,
       "requires": {
         "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.2.0",
+        "strnum": "^2.2.2"
       }
     },
     "fdir": {
@@ -7663,13 +7664,13 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
+        "neo-async": "^2.6.2",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
@@ -8372,9 +8373,9 @@
       "dev": true
     },
     "path-expression-matcher": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-      "integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
       "dev": true
     },
     "path-key": {
@@ -8401,9 +8402,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="
     },
     "pify": {
       "version": "2.3.0",
@@ -8684,9 +8685,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
-      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg=="
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw=="
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -8856,9 +8857,9 @@
       }
     },
     "strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
       "dev": true
     },
     "supports-color": {
@@ -9146,9 +9147,9 @@
       "dev": true
     },
     "yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true
     },
     "yargs": {

--- a/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
+++ b/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
@@ -66,14 +66,16 @@ export type ArrayOperator = 'IN';
 
 export type CaseOperator = 'CASE';
 
-export type CaseNode<FilterProps, PropType> = {
-  [K in CaseOperator]: CaseExpression<FilterProps, PropType>;
+export type CaseNode<Entity, PropType> = {
+  [K in CaseOperator]: CaseExpression<Entity, PropType>;
 };
 
-export type CaseExpression<FilterProps, PropType> = {
-  IF: SingleFilterExpr<FilterProps>;
-  THEN: PropType | CaseNode<FilterProps, PropType>;
-  ELSE: PropType | CaseNode<FilterProps, PropType>;
+type InCaseNode<Case> = Case extends CaseNode<infer Entity, infer PropType> ? CaseNode<Entity, PropType[]> : never;
+
+export type CaseExpression<Entity, PropType> = {
+  IF: SingleFilterExpr<Entity>;
+  THEN: PropType | CaseNode<Entity, PropType>;
+  ELSE: PropType | CaseNode<Entity, PropType>;
 };
 
 export type NullOperator = 'NULL';
@@ -102,31 +104,31 @@ export type LengthExprWithModifier =
   { [K in NullOperator]?: never } &
   { [K in ModifierFunction]?: boolean };
 
-export type FilterExpr<T> =
-  { [K in ComparisonOperator]?: T } &
-  { [K in ArrayOperator]?: T[] } &
+export type FilterExpr<T, Case = never> =
+  { [K in ComparisonOperator]?: T | Case } &
+  { [K in ArrayOperator]?: T[] | InCaseNode<Case> } &
   { [K in keyof LengthExpr]?: never };
 
-export type FilterExprWithoutNull<T> =
-  RequireAtLeastOne<FilterExpr<T>> &
+export type FilterExprWithoutNull<T, Case = never> =
+  RequireAtLeastOne<FilterExpr<T, Case>> &
   { [K in NullOperator]?: never } &
   { [K in ModifierFunction]?: boolean };
 
-export type FilterExprWithNull<T> =
-  FilterExpr<T> &
+export type FilterExprWithNull<T, Case = never> =
+  FilterExpr<T, Case> &
   { [K in NullOperator]?: boolean} &
   { [K in ModifierFunction]?: never };
 
-export type MapOperators<T> = LengthExprWithModifier | FilterExprWithoutNull<T> | FilterExprWithNull<T>;
+export type MapOperators<T, Case = never> = LengthExprWithModifier | FilterExprWithoutNull<T, Case> | FilterExprWithNull<T, Case>;
 
 export type SingleFilterExpr<T> = {
   [P in keyof T]?: T[P] extends Array<infer U> | undefined
     ? U extends Record<any, any>
       ? SingleFilterExpr<U> | { NOT?: SingleFilterExpr<U> }
-      : MapOperators<U> | CaseNode<T, T[P]>
+      : MapOperators<U, CaseNode<T, T[P]>>
     : T[P] extends Record<any, any> | undefined
       ? SingleFilterExpr<T[P]> | { NOT?: SingleFilterExpr<T[P]> }
-      : MapOperators<T[P]> | CaseNode<T, T[P]>;
+      : MapOperators<T[P], CaseNode<T, T[P]>>;
 };
 
 export type QueryFilter<T> = SingleFilterExpr<T> & {
@@ -256,6 +258,8 @@ const flattenWhere = (
       entries.push(
         `not ${flattedNot.length > 1 ? '(' : ''}${flattedNot.join(' and ')}${flattedNot.length > 1 ? ')' : ''}`
       );
+    } else if (prop === 'CASE') {
+      entries.push(evaluateCaseExpression(propValue as CaseExpression<any, any>, setModifiers, nestedPaths));
     } else if (propValue) {
       for (const [operator, value] of Object.entries(propValue)) {
         if (value === undefined) continue;
@@ -265,9 +269,11 @@ const flattenWhere = (
               (acc, [first]) => `${first.toLowerCase()}(${acc})`,
               nestedPaths.some((path) => path === prop) ? nestedPaths.join('.') : [...nestedPaths, prop].join('.')
             )} ${comparisonOperatorMap[operator as BinaryOperator]} ${
-              typeof value === 'string'
-                ? setModifiers.reduce((acc, [first]) => `${first}(${acc})`, JSON.stringify(value))
-                : value
+              typeof value === 'object'
+                ? flattenWhere(value, nestedPaths)
+                : typeof value === 'string'
+                  ? setModifiers.reduce((acc, [first]) => `${first}(${acc})`, JSON.stringify(value))
+                  : value
             }`
           );
         } else if ((operator as Operator) === 'NULL') {
@@ -275,7 +281,14 @@ const flattenWhere = (
             `${!value ? 'not ' : ''}${nestedPaths.some((path) => path === prop) ? nestedPaths.join('.') : [...nestedPaths, prop].join('.')} ${comparisonOperatorMap[operator as BinaryOperator]}`
           );
         } else if ((operator as Operator) === 'IN') {
-          if(value.length === 0) {
+          if (typeof value === 'object' && !Array.isArray(value) && value.CASE) {
+            entries.push(
+              `${setModifiers.reduce(
+                (acc, [first]) => `${first}(${acc})`,
+                nestedPaths.some((path) => path === prop) ? nestedPaths.join('.') : [...nestedPaths, prop].join('.')
+              )} ${comparisonOperatorMap[operator as BinaryOperator]} ${evaluateCaseExpression(value.CASE as CaseExpression<any, any>, setModifiers, nestedPaths)}`
+            );
+          } else if(value.length === 0) {
             entries.push('1 = 0')
           } else {
             entries.push(
@@ -319,11 +332,13 @@ const evaluateCaseExpression = <FilterProps, PropType>(
   nestedPaths: string[]
 ): string =>
   `(${flattenWhere(exp.IF, nestedPaths)} ? ${
-    typeof exp.THEN === 'string'
+    typeof exp.THEN === 'string' || Array.isArray(exp.THEN)
       ? setModifiers.reduce((acc, [first]) => `${first}(${acc})`, JSON.stringify(exp.THEN))
-      : exp.THEN
+      : typeof exp.THEN === 'number' || typeof exp.THEN === 'boolean'
+        ? exp.THEN
+        : evaluateCaseExpression((exp.THEN as CaseNode<FilterProps, PropType>).CASE, setModifiers, nestedPaths)
   } : ${
-    typeof exp.ELSE === 'string'
+    typeof exp.ELSE === 'string' || Array.isArray(exp.ELSE)
       ? setModifiers.reduce((acc, [first]) => `${first}(${acc})`, JSON.stringify(exp.ELSE))
       : typeof exp.ELSE === 'number' || typeof exp.ELSE === 'boolean'
         ? exp.ELSE

--- a/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
+++ b/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
@@ -72,7 +72,7 @@ export type CaseNode<FilterProps, PropType> = {
 
 export type CaseExpression<FilterProps, PropType> = {
   IF: SingleFilterExpr<FilterProps>;
-  THEN: PropType;
+  THEN: PropType | CaseNode<FilterProps, PropType>;
   ELSE: PropType | CaseNode<FilterProps, PropType>;
 };
 

--- a/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
+++ b/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
@@ -64,9 +64,23 @@ export type LengthOperator = 'LENGTH';
 
 export type ArrayOperator = 'IN';
 
+export type CaseOperator = 'CASE';
+
+export type CaseNode<FilterProps, PropType> = {
+  [K in CaseOperator]: CaseExpression<FilterProps, PropType>;
+};
+
+export type CaseExpression<FilterProps, PropType> = {
+  IF: SingleFilterExpr<FilterProps>;
+  THEN: PropType;
+  ELSE: PropType | CaseNode<FilterProps, PropType>;
+};
+
 export type NullOperator = 'NULL';
 
-export type Operator = ComparisonOperator | ArrayOperator | NullOperator;
+export type Operator = ComparisonOperator | ArrayOperator | CaseOperator | NullOperator;
+
+export type BinaryOperator = Exclude<Operator, CaseOperator>;
 
 export type ModifierFunction = 'LOWER' | 'TRIM';
 
@@ -109,10 +123,10 @@ export type SingleFilterExpr<T> = {
   [P in keyof T]?: T[P] extends Array<infer U> | undefined
     ? U extends Record<any, any>
       ? SingleFilterExpr<U> | { NOT?: SingleFilterExpr<U> }
-      : MapOperators<U>
+      : MapOperators<U> | CaseNode<T, T[P]>
     : T[P] extends Record<any, any> | undefined
       ? SingleFilterExpr<T[P]> | { NOT?: SingleFilterExpr<T[P]> }
-      : MapOperators<T[P]>;
+      : MapOperators<T[P]> | CaseNode<T, T[P]>;
 };
 
 export type QueryFilter<T> = SingleFilterExpr<T> & {
@@ -178,7 +192,7 @@ const comparisonOperatorList: ComparisonOperator[] = [
   'LIKE'
 ];
 
-const comparisonOperatorMap: Record<Operator, string> = {
+const comparisonOperatorMap: Record<BinaryOperator, string> = {
   EQ: '=',
   NE: '!=',
   LT: '<',
@@ -250,13 +264,15 @@ const flattenWhere = (
             `${setModifiers.reduce(
               (acc, [first]) => `${first.toLowerCase()}(${acc})`,
               nestedPaths.some((path) => path === prop) ? nestedPaths.join('.') : [...nestedPaths, prop].join('.')
-            )} ${comparisonOperatorMap[operator as Operator]} ${
-              typeof value === 'string' ? JSON.stringify(value) : value
+            )} ${comparisonOperatorMap[operator as BinaryOperator]} ${
+              typeof value === 'string'
+                ? setModifiers.reduce((acc, [first]) => `${first}(${acc})`, JSON.stringify(value))
+                : value
             }`
           );
         } else if ((operator as Operator) === 'NULL') {
           entries.push(
-            `${!value ? 'not ' : ''}${nestedPaths.some((path) => path === prop) ? nestedPaths.join('.') : [...nestedPaths, prop].join('.')} ${comparisonOperatorMap[operator as Operator]}`
+            `${!value ? 'not ' : ''}${nestedPaths.some((path) => path === prop) ? nestedPaths.join('.') : [...nestedPaths, prop].join('.')} ${comparisonOperatorMap[operator as BinaryOperator]}`
           );
         } else if ((operator as Operator) === 'IN') {
           if(value.length === 0) {
@@ -266,11 +282,13 @@ const flattenWhere = (
               `${setModifiers.reduce(
                 (acc, [first]) => `${first.toLowerCase()}(${acc})`,
                 nestedPaths.some((path) => path === prop) ? nestedPaths.join('.') : [...nestedPaths, prop].join('.')
-              )} ${comparisonOperatorMap[operator as Operator]} [${value.map((v: string | number) =>
-                typeof v === 'string' ? JSON.stringify(v) : v
+              )} ${comparisonOperatorMap[operator as BinaryOperator]} [${value.map((v: string | number) =>
+                typeof v === 'string' ? setModifiers.reduce((acc, [first]) => `${first}(${acc})`, JSON.stringify(v)) : v
               )}]`
             );
           }
+        } else if ((operator as Operator) === 'CASE') {
+          entries.push(evaluateCaseExpression(value as CaseExpression<any, any>, setModifiers, nestedPaths));
         } else if ((operator as LengthOperator) === 'LENGTH') {
           const lengthProp = `length(${setModifiers.reduce(
             (acc, [first]) => `${first.toLowerCase()}(${acc})`,
@@ -294,6 +312,23 @@ const flattenWhere = (
   }
   return entries;
 };
+
+const evaluateCaseExpression = <FilterProps, PropType>(
+  exp: CaseExpression<FilterProps, PropType>,
+  setModifiers: [string, any][],
+  nestedPaths: string[]
+): string =>
+  `(${flattenWhere(exp.IF, nestedPaths)} ? ${
+    typeof exp.THEN === 'string'
+      ? setModifiers.reduce((acc, [first]) => `${first}(${acc})`, JSON.stringify(exp.THEN))
+      : exp.THEN
+  } : ${
+    typeof exp.ELSE === 'string'
+      ? setModifiers.reduce((acc, [first]) => `${first}(${acc})`, JSON.stringify(exp.ELSE))
+      : typeof exp.ELSE === 'number' || typeof exp.ELSE === 'boolean'
+        ? exp.ELSE
+        : evaluateCaseExpression((exp.ELSE as CaseNode<FilterProps, PropType>).CASE, setModifiers, nestedPaths)
+  })`;
 
 const assembleOrderBy = (orderBy: OrderBy<any>[] = []): Record<string, string> => {
   if(!orderBy.length) {


### PR DESCRIPTION
This PR introduces the support of the ternary operator in filter expressions. The operator's name is `CASE` and works with `IF`, `THEN`, `ELSE`. 
```
wServices.article.some({
  where: {
    unit: {
	  EQ: {
	    CASE: {
		  IF: <filterExpression>,
		  THEN: <value>,
		  ELSE: <value>
	    }	  
	  }
    }
  }
})
```

Nested ternary operators are also possible

```
wServices.article.some({
  where: {
    unit: {
	  EQ: {
        CASE: {
          IF: <filterExpression>,
          THEN: <value>,
          ELSE: {
            CASE: {
              IF: <filterExpression>,
              THEN: <value>,
              ELSE: <value>
            }
          }
        }	  
	  }
    }
  }
})
```