### PR TITLE
Adjust sdk for using POST request

### DIFF
--- a/src/generator/01-base/static/queriesWithFilter.ts.txt
+++ b/src/generator/01-base/static/queriesWithFilter.ts.txt
@@ -169,12 +169,20 @@ const _some = (
   const usePost = cfg?.usePost ?? globalConfig?.usePost
   const payload = {
       serializeNulls: query?.serializeNulls,
-      additionalProperties: query?.properties?.join(','),
-      properties: query?.select ? flattenSelect(query.select).join(',') : undefined,
-      includeReferencedEntities: query?.include ? Object.keys(query.include).join(',') : undefined,
+      additionalProperties: usePost ? query?.properties : query?.properties?.join(','),
+      properties: query?.select
+        ? usePost
+          ? flattenSelect(query.select)
+          : flattenSelect(query.select).join(',')
+        : undefined,
+      includeReferencedEntities: query?.include
+        ? usePost
+          ? Object.keys(query.include)
+          : Object.keys(query.include).join(',')
+        : undefined,
       ...flattenOrFilter(query?.or),
       ...flattenFilter(query?.filter),
-      ...flattenSort(query?.sort),
+      ...flattenSort(query?.sort, usePost),
       ...query?.params,
       ...query?.pagination
   }

--- a/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
+++ b/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
@@ -404,15 +404,19 @@ const _some = (
   const usePost = cfg?.usePost ?? globalConfig?.usePost;
   const payload = {
     serializeNulls: query?.serializeNulls,
-    additionalProperties: query?.properties?.join(','),
-    properties: query?.select
-      ? flattenSelect(query.select).join(',')
+    additionalProperties: usePost ? query?.properties : query?.properties?.join(','),
+      properties: query?.select
+        ? usePost
+          ? flattenSelect(query.select)
+          : flattenSelect(query.select).join(',')
       : undefined,
     includeReferencedEntities: query?.include
-      ? Object.keys(query.include).join(',')
-      : undefined,
+      ? usePost
+          ? Object.keys(query.include)
+          : Object.keys(query.include).join(',')
+        : undefined,
     ...assembleFilterParam(query?.where),
-    ...flattenSort(query?.sort),
+    ...flattenSort(query?.sort, usePost),
     ...assembleOrderBy(query?.orderBy),
     ...query?.params,
     ...query?.pagination

--- a/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
+++ b/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
@@ -1,4 +1,4 @@
-const flattenOrderBy = (orderBy: OrderBy<any>[] = []): string => {
+const flattenOrderBy = (orderBy: OrderBy<any>[] = []): string[] => {
 
   const applyModifiers = (property: string, modifier: { TRIM?: boolean; LOWER?: boolean; LENGTH?: boolean }) => {
     let result = property;
@@ -48,7 +48,7 @@ const flattenOrderBy = (orderBy: OrderBy<any>[] = []): string => {
     return `${property} ${sort}`;
   };
 
-  return orderBy.map(flattenSingle).join(', ');
+  return orderBy.map(flattenSingle);
 }
 
 export type ComparisonOperator =
@@ -345,12 +345,22 @@ const evaluateCaseExpression = <FilterProps, PropType>(
         : evaluateCaseExpression((exp.ELSE as CaseNode<FilterProps, PropType>).CASE, setModifiers, nestedPaths)
   })`;
 
-const assembleOrderBy = (orderBy: OrderBy<any>[] = []): Record<string, string> => {
+const assembleOrderBy = (orderBy: OrderBy<any>[] = [], usePost?: boolean): Record<string, string | string[]> => {
   if(!orderBy.length) {
     return {}
   }
-  const flattedOrderBy = flattenOrderBy(orderBy);
-  return flattedOrderBy.length ? { orderBy: flattedOrderBy } : {};
+  const flattedOrderByList = flattenOrderBy(orderBy);
+
+  if(!flattedOrderByList.length) {
+    return {};
+  }
+
+  if(usePost) {
+    return { orderBy: flattedOrderByList };
+  }
+
+  const flattedOrderBy = flattedOrderByList.join(',');
+  return { orderBy: flattedOrderBy };
 }
 
 const assembleFilterParam = (
@@ -417,7 +427,7 @@ const _some = (
         : undefined,
     ...assembleFilterParam(query?.where),
     ...flattenSort(query?.sort, usePost),
-    ...assembleOrderBy(query?.orderBy),
+    ...assembleOrderBy(query?.orderBy, usePost),
     ...query?.params,
     ...query?.pagination
   };

--- a/src/generator/01-base/static/utils.ts.txt
+++ b/src/generator/01-base/static/utils.ts.txt
@@ -12,7 +12,8 @@ const flattenSelect = (obj: Select<any, any> = {}): string[] => {
   return entries;
 };
 
-export const flattenSort = (obj: Sort<any>[] = []): { sort?: string } => {
+export const flattenSort = (obj: Sort<any>[] = [], usePost?: boolean):
+{ sort?: string } | { orderBy?: string[] } | Record<string, never> => {
   const flatten = (obj: Sort<any>, base = ''): string | undefined => {
     const [key, value] = Object.entries(obj ?? {})[0] ?? [];
 
@@ -22,13 +23,23 @@ export const flattenSort = (obj: Sort<any>[] = []): { sort?: string } => {
       if (typeof value === 'object') {
         return flatten(value, path ? `${path}.` : '');
       } else if (['asc', 'desc'].includes(value)) {
-        return `${value === 'desc' ? '-' : ''}${path}`;
+        return `${!usePost && value === 'desc' ? '-' : ''}${path}${usePost && value === 'desc' ? ' desc' : ''}`;
       }
     }
 
     return undefined;
   };
 
-  const sorts = obj.map((v) => flatten(v)).filter(Boolean);
-  return sorts.length ? { sort: sorts.join(',') } : {};
+
+  const sorts = obj.map((v) => flatten(v)).filter((x): x is string => typeof x === 'string');
+
+  if (!sorts.length) {
+    return {};
+  }
+
+  if (usePost) {
+    return { orderBy: sorts };
+  } else {
+    return { sort: sorts.join(',') };
+  }
 };


### PR DESCRIPTION
To make use of queries using the POST method `orderBy` instead of `sort` has to be used in the payload. Therefor the utility function `flattenSort` was adapted and the payload assembly of the `_some` function was adapted, too.