### PR TITLE
Add correct type safety to orderBy

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ With the some function you can order requested data. You can either merely order
  * ?orderBy=createdDate asc
  */
 wServices['article'].some({
-  orderBy: [{ FIELD: 'createdDate', SORT: 'asc' }]
+  orderBy: [{ FIELD: { createdDate: true }, SORT: 'asc' }]
 });
 ```
 
@@ -435,7 +435,7 @@ wServices['article'].some({
  * ?orderBy=createdDate asc, articleNumber desc
  */
 wServices['article'].some({
-  orderBy: [{ FIELD: 'createdDate' }, { FIELD: 'articleNumber', SORT: 'desc' }]
+  orderBy: [{ FIELD: { createdDate: true } }, { FIELD: { articleNumber: true }, SORT: 'desc' }]
 });
 ```
 
@@ -457,7 +457,7 @@ wServices['article'].some({
       ELSE: 3,
       SORT: 'asc'
     },
-    { FIELD: 'articleNumber' }
+    { FIELD: { articleNumber: true } }
   ]
 });
 ```
@@ -474,8 +474,8 @@ The `THEN` and `ELSE` values can also be a `FieldOrderBy` to fall back to a fiel
 wServices['article'].some({
   orderBy: [
     {
-      CASE: [{ WHEN: { internalNote: { NULL: false } }, THEN: { FIELD: 'articleNumber' } }],
-      ELSE: { FIELD: 'createdDate' },
+      CASE: [{ WHEN: { internalNote: { NULL: false } }, THEN: { FIELD: { articleNumber: true } } }],
+      ELSE: { FIELD: { createdDate: true } },
       SORT: 'asc'
     }
   ]
@@ -491,7 +491,7 @@ For properties that are objects or arrays of objects, use dot-notation to refere
  * ?orderBy=articlePrices.price asc
  */
 wServices['article'].some({
-  orderBy: [{ FIELD: 'articlePrices.price', SORT: 'asc' }]
+  orderBy: [{ FIELD: { articlePrices: { price: true } }, SORT: 'asc' }]
 });
 ```
 
@@ -511,7 +511,7 @@ wServices['party'].some({
       TRIM: true,
       SORT: 'desc'
     },
-    { FIELD: 'firstName' }
+    { FIELD: { firstName: true } }
   ]
 });
 ```

--- a/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
+++ b/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
@@ -126,36 +126,36 @@ export type QueryFilter<T> = SingleFilterExpr<T> & {
   };
 };
 
-export type ConditionalOrderByCase<E> = {
-  WHEN: QueryFilter<E>;
-  THEN: number | FieldOrderBy<E>;
+export type ConditionalOrderByCase<F> = {
+  WHEN: QueryFilter<F>;
+  THEN: number | FieldOrderBy<F>;
 };
 
-export type ConditionalOrderBy<E> = {
-  CASE: ConditionalOrderByCase<E>[];
-  ELSE: number | FieldOrderBy<E>;
+export type ConditionalOrderBy<F> = {
+  CASE: ConditionalOrderByCase<F>[];
+  ELSE: number | FieldOrderBy<F>;
   SORT?: 'asc' | 'desc';
 };
 
-export type FieldPath<T> = {
+export type FieldPath<T, Depth extends 0[] = []> = Depth['length'] extends 3 ? never : {
   [K in keyof T & string]: NonNullable<T[K]> extends Array<infer U>
     ? U extends Record<any, any>
-      ? `${K}.${FieldPath<U>}`
+      ? `${K}.${FieldPath<U, [...Depth, 0]>}`
       : never
     : NonNullable<T[K]> extends Record<any, any>
-      ? K | `${K}.${FieldPath<NonNullable<T[K]>>}`
+      ? K | `${K}.${FieldPath<NonNullable<T[K]>, [...Depth, 0]>}`
       : K;
 }[keyof T & string];
 
-export type FieldOrderBy<E> = {
-  FIELD: FieldPath<E>;
+export type FieldOrderBy<F> = {
+  FIELD: FieldPath<F>;
   SORT?: 'asc' | 'desc';
   LOWER?: boolean;
   TRIM?: boolean;
   LENGTH?: boolean;
 };
 
-export type OrderBy<E> = FieldOrderBy<E> | ConditionalOrderBy<E>;
+export type OrderBy<F> = FieldOrderBy<F> | ConditionalOrderBy<F>;
 
 export type CountQuery<F> = {
   where?: QueryFilter<F>;
@@ -171,7 +171,7 @@ type SomeQueryBase<E, F, I, P> = {
 };
 
 export type SomeQuery<E, F, I, P> = SomeQueryBase<E, F, I, P> &
-  ({ sort?: Sort<E>[]; orderBy?: never } | { sort?: never; orderBy?: OrderBy<E>[] });
+  ({ sort?: Sort<E>[]; orderBy?: never } | { sort?: never; orderBy?: OrderBy<F>[] });
 
 const comparisonOperatorList: ComparisonOperator[] = [
   'EQ',

--- a/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
+++ b/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
@@ -19,11 +19,17 @@ const flattenOrderBy = (orderBy: OrderBy<any>[] = []): string[] => {
   ): orderByItem is ConditionalOrderBy<any> =>
     !!orderByItem && typeof orderByItem === 'object' && 'CASE' in orderByItem;
 
+  /** Converts a OrderableField object to a dot-notation string. OrderableField guarantees exactly one key per level. */
+  const flattenField = (field: OrderableField<any>): string => {
+    const [[key, value]] = Object.entries(field);
+    return typeof value === 'object' && value !== null ? `${key}.${flattenField(value as OrderableField<any>)}` : key;
+  };
+
   const flattenValue = (value: number | FieldOrderBy<any>): string => {
     if (typeof value === 'number') {
       return value.toString();
     }
-    return applyModifiers(value.FIELD, value);
+    return applyModifiers(flattenField(value.FIELD), value);
   };
 
   const flattenConditional = (item: ConditionalOrderBy<any>): string => {
@@ -43,7 +49,7 @@ const flattenOrderBy = (orderBy: OrderBy<any>[] = []): string[] => {
     }
 
     const field = orderByItem as FieldOrderBy<any>;
-    const property = applyModifiers(field.FIELD, field);
+    const property = applyModifiers(flattenField(field.FIELD), field);
     const sort = field.SORT === 'desc' ? 'desc' : 'asc';
     return `${property} ${sort}`;
   };
@@ -137,18 +143,14 @@ export type ConditionalOrderBy<F> = {
   SORT?: 'asc' | 'desc';
 };
 
-export type FieldPath<T, Depth extends 0[] = []> = Depth['length'] extends 3 ? never : {
-  [K in keyof T & string]: NonNullable<T[K]> extends Array<infer U>
-    ? U extends Record<any, any>
-      ? `${K}.${FieldPath<U, [...Depth, 0]>}`
-      : never
-    : NonNullable<T[K]> extends Record<any, any>
-      ? K | `${K}.${FieldPath<NonNullable<T[K]>, [...Depth, 0]>}`
-      : K;
-}[keyof T & string];
+export type OrderableField<F> = {
+  [K in keyof F]-?: NonNullable<F[K]> extends Record<any, any>
+    ? { [P in K]: OrderableField<NonNullable<F[K]>> } & { [P in Exclude<keyof F, K>]?: never }
+    : { [P in K]: boolean } & { [P in Exclude<keyof F, K>]?: never };
+}[keyof F];
 
 export type FieldOrderBy<F> = {
-  FIELD: FieldPath<F>;
+  FIELD: OrderableField<F>;
   SORT?: 'asc' | 'desc';
   LOWER?: boolean;
   TRIM?: boolean;


### PR DESCRIPTION
This PR completes the type safety of `OrderBy` by not taking the entity props as reference, but the properties of the `*_Filter_Props` types. Since the types can become pretty complex, which can break typescript, the syntax was changed from a `.` notation to a object definition as used for the `include` parameter, e.g.

```typescript
wServices.article.some({
  orderBy: [
    {
      FIELD: {
        articleCategory: {
          name: true
        }
      }
    }
  ]
});
```

The `README.md` was adapted correspondingly.