### PR TITLE
Make properties of *_Some_References deeply optional

### DIFF
--- a/src/generator/04-services/endpoints/some.ts
+++ b/src/generator/04-services/endpoints/some.ts
@@ -68,7 +68,7 @@ const resolveArrayReferenceProperties = (
     ([property, propertyMetaData]): ObjectProperty[] => {
       if (propertyMetaData.type === 'array') {
         if (propertyMetaData.entity === 'onlyId') {
-          return [{ key: property, value: [{ key: 'id', value: 'boolean' }] }];
+          return [{ key: property, value: [{ key: 'id', value: 'boolean', optional: true }], optional: true }];
         }
 
         if (!propertyMetaData.entity) {
@@ -85,11 +85,11 @@ const resolveArrayReferenceProperties = (
           return [];
         }
 
-        return [{ key: property, value: nestedProperties }];
+        return [{ key: property, value: nestedProperties, optional: true }];
       }
 
       if (property.endsWith('Id')) {
-        return [{ key: property, value: 'boolean' }];
+        return [{ key: property, value: 'boolean', optional: true }];
       }
 
       return [];
@@ -114,7 +114,7 @@ const resolveReferences = (entity: string, entities: Map<string, GeneratedEntity
         if (propertyMetaData.entity === 'onlyId') {
           references.push({
             name: property,
-            type: generateObject([{ key: 'id', value: 'boolean' }])
+            type: generateObject([{ key: 'id', value: 'boolean', optional: true }])
           });
         } else {
           const nestedProperties = resolveArrayReferenceProperties(propertyMetaData.entity || '', entities);

--- a/src/ts/generateObject.spec.ts
+++ b/src/ts/generateObject.spec.ts
@@ -62,4 +62,21 @@ describe('generateObject', () => {
     expect(result).toContain('/** A number */');
     expect(result).toContain('x: 1');
   });
+
+  it('renders optional properties with a question mark', () => {
+    const result = generateObject([{ key: 'x', value: 1, optional: true }]);
+    expect(result).toContain('x?: 1');
+  });
+
+  it('does not render question mark when optional is false', () => {
+    const result = generateObject([{ key: 'x', value: 1, optional: false }]);
+    expect(result).toContain('x: 1');
+    expect(result).not.toContain('x?');
+  });
+
+  it('does not render question mark when optional is not set', () => {
+    const result = generateObject([{ key: 'x', value: 1 }]);
+    expect(result).toContain('x: 1');
+    expect(result).not.toContain('x?');
+  });
 });

--- a/src/ts/generateObject.ts
+++ b/src/ts/generateObject.ts
@@ -5,12 +5,13 @@ export interface ObjectProperty {
   key: string;
   value: string | number | undefined | null | boolean | ObjectProperty[];
   comment?: string;
+  optional?: boolean;
 }
 
 export const generateObject = (properties: ObjectProperty[]): string => {
   const body = [];
 
-  for (const { key, value, comment } of properties) {
+  for (const { key, value, comment, optional } of properties) {
     if (value === undefined) {
       continue;
     }
@@ -19,10 +20,12 @@ export const generateObject = (properties: ObjectProperty[]): string => {
       const str = generateObject(value);
 
       if (str.length > 2) {
-        body.push(`${comment ? generateInlineComment(comment) + '\n' : ''}${key}: ${str}`);
+        body.push(`${comment ? generateInlineComment(comment) + '\n' : ''}${key}${optional ? '?' : ''}: ${str}`);
       }
     } else {
-      body.push(`${comment ? generateInlineComment(comment) + '\n' : ''}${key}: ${String(value)}`);
+      body.push(
+        `${comment ? generateInlineComment(comment) + '\n' : ''}${key}${optional ? '?' : ''}: ${String(value)}`
+      );
     }
   }
 


### PR DESCRIPTION
This PR makes all properties of `*_Some_References` types, root level and nested properties, optional. This ensures convenience so that not all nested properties have to be set, but following is sufficient enough

```typescript
wServices.article.some({
  include: {
    quantityConversions: {
      unitId: true
    }
  }
});
``` 

Before one had to set all unwanted properties to false like this 
```typescript
wServices.article.some({
  include: {
    quantityConversions: {
      createdUserId: false,
      lastEditedUserId: false,
      unitId: true
    }
  }
});
```