### PR TITLE
Update npm in ci workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -56,13 +56,13 @@ Files in `src/generator/01-base/static/*.ts.txt` are raw TypeScript strings impo
 
 ## Commands
 
-| Task | Command |
-|------|---------|
-| Build CLI | `npm run build` |
-| Run tests | `npm test` |
-| Lint | `npm run lint` |
-| Format check | `npm run prettier` |
-| Full CI check | `npm run ci` |
+| Task                      | Command                                              |
+| ------------------------- | ---------------------------------------------------- |
+| Build CLI                 | `npm run build`                                      |
+| Run tests                 | `npm test`                                           |
+| Lint                      | `npm run lint`                                       |
+| Format check              | `npm run prettier`                                   |
+| Full CI check             | `npm run ci`                                         |
 | Generate SDK (local file) | `./bin/cli.js test/openapi_v3.json --target browser` |
 
 ## Testing
@@ -84,4 +84,3 @@ Files in `src/generator/01-base/static/*.ts.txt` are raw TypeScript strings impo
 - The `sdk/` directory is **generated output** — never edit files there manually; they are deleted and regenerated on each build.
 - The project uses ESM (`"type": "module"`) throughout with `import ... with { type: 'json' }` for JSON imports.
 - Rollup config uses `tsconfig.node.json`; the generated SDK uses `tsconfig.sdk.json`.
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.14.0
+          node-version: 24.11.1
 
       - name: Install dependencies
         run: npm ci
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.14.0
+          node-version: 24.11.1
 
       - name: Install dependencies
         run: npm ci
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.14.0
+          node-version: 24.11.1
 
       - name: Install dependencies
         run: npm ci
@@ -95,7 +95,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.14.0
+          node-version: 24.11.1
 
       - name: Download dist files
         uses: actions/download-artifact@v4
@@ -124,7 +124,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22.14.0
+          node-version: 24.11.1
 
       - name: Download dist files
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This PR updates the github CI workflow so that `node` and implictly `npm` match the versions introduced in `e6d8024` with volta support / pinned versions. In said commit the required `npm` version was increased to `npm >= 11`, but since the CI used `node` version `22.14.0` which bundles `npm` version `10.9.2` the github actions failed. Now the CI workflow uses `node` version `24.11.1` as pinned in `package.json`