### PR TITLE
Add cjs entry point and enforce named exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
     "npm": ">=11"
   },
   "types": "./sdk/dist/index.d.ts",
+  "main": "./sdk/dist/index.cjs",
   "module": "./sdk/dist/index.js",
   "type": "module",
   "exports": {
     ".": {
       "types": "./sdk/dist/index.d.ts",
-      "import": "./sdk/dist/index.js"
+      "import": "./sdk/dist/index.js",
+      "require": "./sdk/dist/index.cjs"
     }
   },
   "scripts": {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -24,6 +24,7 @@ const emitDeclarations = (tsconfigPath: string, outDir: string) => {
 const generateOutput = (config: OutputOptions): OutputOptions => ({
   sourcemap: false,
   banner: `/* weclapp sdk */`,
+  exports: 'named',
   ...config
 });
 


### PR DESCRIPTION
This PR adds an main entry point in `package.json` and sets the bundler's exports to `named`. This ensures commonJS compatibility.