### PR TITLE
Disallow arrays in orderBy of SomeQuery

### DIFF
--- a/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
+++ b/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
@@ -163,8 +163,11 @@ export type CountQuery<F> = {
   where?: QueryFilter<F>;
 };
 
+type ContainsArray<T> =
+  T extends any[] ? true : never;
+
 type NonArrayProps<T> = {
-  [K in keyof T as T[K] extends any[] ? never : K]: T[K];
+  [K in keyof T as [ContainsArray<T[K]>] extends [never] ? K : never]: T[K]
 };
 
 type SomeQueryBase<E, F, I, P> = {

--- a/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
+++ b/src/generator/01-base/static/queriesWithQueryLanguage.ts.txt
@@ -163,6 +163,10 @@ export type CountQuery<F> = {
   where?: QueryFilter<F>;
 };
 
+type NonArrayProps<T> = {
+  [K in keyof T as T[K] extends any[] ? never : K]: T[K];
+};
+
 type SomeQueryBase<E, F, I, P> = {
   serializeNulls?: boolean;
   include?: I;
@@ -173,7 +177,7 @@ type SomeQueryBase<E, F, I, P> = {
 };
 
 export type SomeQuery<E, F, I, P> = SomeQueryBase<E, F, I, P> &
-  ({ sort?: Sort<E>[]; orderBy?: never } | { sort?: never; orderBy?: OrderBy<F>[] });
+  ({ sort?: Sort<E>[]; orderBy?: never } | { sort?: never; orderBy?: OrderBy<NonArrayProps<F>>[] });
 
 const comparisonOperatorList: ComparisonOperator[] = [
   'EQ',


### PR DESCRIPTION
This PR introduces a `NonArrayProps` type which strips away array properties of a type to be able to use `orderBy` in a `SomeQuery` with proper types. The types which can be used for `orderBy` in a `SomeQuery` are basically the `*_Filter_Props` types without arrays.